### PR TITLE
Endpoint for listing subprojects

### DIFF
--- a/apps/core/projects/dependencies.py
+++ b/apps/core/projects/dependencies.py
@@ -17,7 +17,6 @@ class ProjectAccessChecker:
         user_id = request.state.user_id
 
         project = impl_get_project(project_id)
-        print(project)
 
         # Check if user is a participant in the project
         if user_id not in project.participants_access.keys():

--- a/apps/core/projects/implementation.py
+++ b/apps/core/projects/implementation.py
@@ -105,6 +105,11 @@ def impl_post_subproject(subproject: SubProjectPost, current_user_id: int, proje
         )
 
 
+def impl_get_subprojects(project_id: int) -> List[SubProject]:
+    with get_connection() as con:
+        return db_get_subprojects(con, project_id)
+
+
 def impl_get_subproject(project_id: int, subproject_id: int):
     try:
         with get_connection() as con:

--- a/apps/core/projects/router.py
+++ b/apps/core/projects/router.py
@@ -86,6 +86,14 @@ async def put_participant_name(project_id: int, name: str):
     return impl_put_name(project_id, name)
 
 
+@router.get("/{project_id}/subproject/",
+            summary="Get subprojects in project",
+            dependencies=[Depends(ProjectAccessChecker(AccessLevel.list_can_read()))],
+            response_model=List[SubProject])
+async def get_subprojects(project_id: int):
+    return impl_get_subprojects(project_id)
+
+
 @router.get("/{project_id}/subproject/{subproject_id}",
             summary="Get subproject",
             description="Get a specific project using subproject ID")


### PR DESCRIPTION
As per request, an endpoint as been added to list all subprojects that exists under a specific project.

It is ensured that the user has access to the project before the listing is returned.

Bonus: Removed pointless print in project dependency code