### PR TITLE
Endpoint conventions

### DIFF
--- a/apps/core/applications/router.py
+++ b/apps/core/applications/router.py
@@ -9,7 +9,7 @@ from apps.core.applications.models import Application
 router = APIRouter()
 
 
-@router.get("/",
+@router.get("",
             summary="Lists all applications",
             description="Produces a list of applications in alphabetical order",
             response_model=List[Application],

--- a/apps/core/individuals/router.py
+++ b/apps/core/individuals/router.py
@@ -8,7 +8,7 @@ import apps.core.individuals.implementation as impl
 router = APIRouter()
 
 
-@router.post("/",
+@router.post("",
              summary="Create individual",
              description="Create a new individual",
              response_model=models.Individual)
@@ -37,7 +37,7 @@ async def put_individual_name(individual_id, individual_name):
     return impl.impl_put_individual_name(individual_id, individual_name, archetype=False)
 
 
-@router.post("/{individual_id}/parameters/",
+@router.post("/{individual_id}/parameters",
              summary="Add parameter to individual",
              response_model=models.IndividualParameter)
 async def post_parameter(individual_id: int, parameter: models.IndividualParameterPost):
@@ -51,7 +51,7 @@ async def delete_parameter(individual_id: int, parameter_id: int):
     return impl.impl_delete_parameter(individual_id, parameter_id)
 
 
-@router.post("/archetypes/",
+@router.post("/archetypes",
              summary="Create individual archetype",
              description="Create a new individual archetype",
              response_model=models.IndividualArchetype)
@@ -66,7 +66,7 @@ async def get_individual_archetype(individual_archetype_id) -> Optional[models.I
     return impl.impl_get_individual_archetype(individual_archetype_id)
 
 
-@router.get("/archetypes/{individual_archetype_id}/individuals/",
+@router.get("/archetypes/{individual_archetype_id}/individuals",
             summary="Get all individuals that uses this archetype",
             response_model=List[models.Individual])
 async def get_archetype_individuals(individual_archetype_id: int):
@@ -87,7 +87,7 @@ async def put_individual_archetype_name(individual_archetype_id, individual_name
     return impl.impl_put_individual_name(individual_archetype_id, individual_name, archetype=True)
 
 
-@router.delete("/archetypes/{individual_archetype_id}/individuals/",
+@router.delete("/archetypes/{individual_archetype_id}/individuals",
                response_model=int,
                summary="Delete all individuals for specific archetype")
 async def delete_archetype_individuals(individual_archetype_id: int):

--- a/apps/core/measurements/router.py
+++ b/apps/core/measurements/router.py
@@ -11,14 +11,14 @@ from apps.core.authentication.utils import get_current_active_user
 router = APIRouter()
 
 
-@router.post("/sets/",
+@router.post("/sets",
              summary="Post measurement set",
              response_model=models.MeasurementSet)
 async def post_measurement_set(measurement_set: models.MeasurementSetPost, subproject_id: Optional[int] = None):
     return impl.impl_post_measurement_set(measurement_set, subproject_id=subproject_id)
 
 
-@router.get("/sets/",
+@router.get("/sets",
             summary="Get measurement sets",
             response_model=List[models.MeasurementSetListing])
 async def get_measurement_sets(subproject_id: Optional[int] = None):
@@ -49,7 +49,7 @@ async def delete_measurement_set(measurement_set_id: int) -> bool:
     return impl.impl_delete_measurement_set(measurement_set_id)
 
 
-@router.post("/sets/{measurement_set_id}/measurements/",
+@router.post("/sets/{measurement_set_id}/measurements",
              summary="Post measurement",
              response_model=models.Measurement)
 async def post_measurement(measurement: models.MeasurementPost, measurement_set_id: int):
@@ -71,7 +71,7 @@ async def delete_measurement(measurement_set_id: int, measurement_id: int):
     return impl.impl_delete_measurement(measurement_set_id, measurement_id)
 
 
-@router.get("/sets/{measurement_set_id}/measurements/{measurement_id}/results/",
+@router.get("/sets/{measurement_set_id}/measurements/{measurement_id}/results",
             summary="Get measurement result data",
             description="Search for specific data measurement. Dates are provided as UNIX timestamp in milliseconds.",
             response_model=List[models.MeasurementResultData])
@@ -89,7 +89,7 @@ async def get_measurement_results(measurement_set_id: int,
     return impl.impl_get_measurement_results(measurement_id, dtype, date_class, date_from, date_to)
 
 
-@router.post("/sets/{measurement_set_id}/measurements/{measurement_id}/results/",
+@router.post("/sets/{measurement_set_id}/measurements/{measurement_id}/results",
              summary="Post measurement result data",
              response_model=models.MeasurementResultData)
 async def post_measurement_result(measurement_id: int, measurement_data_post: models.MeasurementResultDataPost):

--- a/apps/core/projects/router.py
+++ b/apps/core/projects/router.py
@@ -12,7 +12,7 @@ from apps.core.users.models import User
 router = APIRouter()
 
 
-@router.get("/",
+@router.get("",
             summary="Lists all projects",
             description="Lists all projects in alphabetical order",
             response_model=List[models.ProjectListing])
@@ -50,7 +50,7 @@ async def get_project(project_id: int):
     return impl.impl_get_project(project_id)
 
 
-@router.post("/",
+@router.post("",
              summary="Create project",
              description="Create a new empty project. The current user is automatically set as the owner.",
              response_model=models.Project,
@@ -69,7 +69,7 @@ async def delete_project(project_id: int):
     return impl.impl_delete_project(project_id)
 
 
-@router.post("/{project_id}/participants/",
+@router.post("/{project_id}/participants",
              summary="Add participant to project",
              description="Add a participant to a project",
              dependencies=[Depends(ProjectAccessChecker([models.AccessLevel.OWNER, models.AccessLevel.ADMIN]))])
@@ -95,7 +95,7 @@ async def put_participant_name(project_id: int, name: str):
     return impl.impl_put_name(project_id, name)
 
 
-@router.get("/{project_id}/subprojects/",
+@router.get("/{project_id}/subprojects",
             summary="Get subprojects in project",
             dependencies=[Depends(ProjectAccessChecker(models.AccessLevel.list_can_read()))],
             response_model=List[models.SubProject])
@@ -111,7 +111,7 @@ async def get_subproject(project_id: int, subproject_id: int):
     return impl.impl_get_subproject(project_id, subproject_id)
 
 
-@router.post("/{project_id}/subprojects/",
+@router.post("/{project_id}/subprojects",
              summary="Create subproject",
              description="Create a new subproject. Needs to be connected to an existing project.",
              response_model=models.SubProject,

--- a/apps/core/users/router.py
+++ b/apps/core/users/router.py
@@ -11,7 +11,7 @@ from apps.core.users.implementation import impl_get_users, impl_post_user, impl_
 router = APIRouter()
 
 
-@router.get("/",
+@router.get("",
             summary="Lists all users",
             description="Produces a list of users in alphabetical order",
             response_model=List[models.User])
@@ -19,7 +19,7 @@ async def get_users(segment_length: int, index: int):
     return impl_get_users(segment_length, index)
 
 
-@router.post("/",
+@router.post("",
              summary="Create new user",
              response_model=models.User,
              dependencies=[Security(verify_scopes, scopes=['admin'])])

--- a/apps/cvs/router.py
+++ b/apps/cvs/router.py
@@ -19,7 +19,7 @@ CVS_APP_SID = 'MOD.CVS'
 # ======================================================================================================================
 
 @router.get(
-    '/project/get/all/',
+    '/project/get/all',
     summary='Returns all of the user\'s CVS projects',
     response_model=ListChunk[models.CVSProject],
 )
@@ -29,7 +29,7 @@ async def get_all_cvs_project(user: User = Depends(get_current_active_user)) \
 
 
 @router.get(
-    '/project/get/segment/',
+    '/project/get/segment',
     summary='Returns a segment of the user\'s CVS projects',
     response_model=ListChunk[models.CVSProject],
 )
@@ -39,7 +39,7 @@ async def get_segment_cvs_project(index: int, segment_length: int, user: User = 
 
 
 @router.get(
-    '/project/get/{project_id}/',
+    '/project/get/{project_id}',
     summary='Returns a CVS project based on id',
     description='Returns a CVS project based on id',
     response_model=models.CVSProject,
@@ -49,7 +49,7 @@ async def get_csv_project(project_id: int, user: User = Depends(get_current_acti
 
 
 @router.post(
-    '/project/create/',
+    '/project/create',
     summary='Creates a new CVS project',
     response_model=models.CVSProject,
 )
@@ -59,7 +59,7 @@ async def create_csv_project(project_post: models.CVSProjectPost,
 
 
 @router.put(
-    '/project/{project_id}/edit/',
+    '/project/{project_id}/edit',
     summary='Edits a CVS project',
     response_model=models.CVSProject,
 )
@@ -69,7 +69,7 @@ async def edit_csv_project(project_id: int, project_post: models.CVSProjectPost,
 
 
 @router.delete(
-    '/project/{project_id}/delete/',
+    '/project/{project_id}/delete',
     summary='Deletes a CVS project based on id',
     response_model=bool,
 )
@@ -82,7 +82,7 @@ async def delete_cvs_project(project_id: int, user: User = Depends(get_current_a
 # ======================================================================================================================
 
 @router.get(
-    '/project/{project_id}/vcs/get/all/',
+    '/project/{project_id}/vcs/get/all',
     summary='Returns all of VCSs of a project',
     response_model=ListChunk[models.VCS],
 )
@@ -91,7 +91,7 @@ async def get_all_vcs(project_id: int, user: User = Depends(get_current_active_u
 
 
 @router.get(
-    '/project/{project_id}/vcs/get/segment/',
+    '/project/{project_id}/vcs/get/segment',
     summary='Returns a segment of the VCSs of a project',
     response_model=ListChunk[models.VCS],
 )
@@ -110,7 +110,7 @@ async def get_vcs(vcs_id: int, project_id: int, user: User = Depends(get_current
 
 
 @router.post(
-    '/project/{project_id}/vcs/create/',
+    '/project/{project_id}/vcs/create',
     summary='Creates a new VCS in a project',
     response_model=models.VCS,
 )
@@ -120,7 +120,7 @@ async def create_vcs(vcs_post: models.VCSPost, project_id: int,
 
 
 @router.put(
-    '/project/{project_id}/vcs/{vcs_id}/edit/',
+    '/project/{project_id}/vcs/{vcs_id}/edit',
     summary='Edits a VCS',
     response_model=models.VCS,
 )
@@ -130,7 +130,7 @@ async def edit_vcs(vcs_id: int, project_id: int, vcs_post: models.VCSPost,
 
 
 @router.delete(
-    '/project/{project_id}/vcs/{vcs_id}/delete/',
+    '/project/{project_id}/vcs/{vcs_id}/delete',
     summary='Deletes a VCS based on id',
     response_model=bool,
 )
@@ -143,7 +143,7 @@ async def delete_vcs(vcs_id: int, project_id: int, user: User = Depends(get_curr
 # ======================================================================================================================
 
 @router.get(
-    '/project/{project_id}/value-driver/get/all/',
+    '/project/{project_id}/value-driver/get/all',
     summary='Returns all of value drivers of a project',
     response_model=ListChunk[models.VCSValueDriver],
 )
@@ -163,7 +163,7 @@ async def get_value_driver(value_driver_id: int, project_id: int,
 
 
 @router.post(
-    '/project/{project_id}/value-driver/create/',
+    '/project/{project_id}/value-driver/create',
     summary='Creates a new value driver in a project',
     response_model=models.VCSValueDriver,
 )
@@ -173,7 +173,7 @@ async def create_value_driver(vcs_post: models.VCSValueDriverPost, project_id: i
 
 
 @router.put(
-    '/project/{project_id}/value-driver/{value_driver_id}/edit/',
+    '/project/{project_id}/value-driver/{value_driver_id}/edit',
     summary='Edits a value driver',
     response_model=models.VCSValueDriver,
 )
@@ -183,7 +183,7 @@ async def edit_value_driver(value_driver_id: int, project_id: int, vcs_post: mod
 
 
 @router.delete(
-    '/project/{project_id}/value-driver/{value_driver_id}/delete/',
+    '/project/{project_id}/value-driver/{value_driver_id}/delete',
     summary='Deletes a value driver',
     response_model=bool,
 )
@@ -197,7 +197,7 @@ async def delete_value_driver(value_driver_id: int, project_id: int,
 # ======================================================================================================================
 
 @router.get(
-    '/vcs/iso-processes/get/all/',
+    '/vcs/iso-processes/get/all',
     summary='Returns all ISO processes',
     response_model=ListChunk[models.VCSISOProcess],
 )
@@ -210,7 +210,7 @@ async def get_all_iso_process() -> ListChunk[models.VCSISOProcess]:
 # ======================================================================================================================
 
 @router.get(
-    '/project/{project_id}/subprocess/get/all/',
+    '/project/{project_id}/subprocess/get/all',
     summary='Returns all subprocesses of a project',
     response_model=ListChunk[models.VCSSubprocess],
 )
@@ -230,7 +230,7 @@ async def get_subprocess(subprocess_id: int, project_id: int,
 
 
 @router.post(
-    '/project/{project_id}/subprocess/create/',
+    '/project/{project_id}/subprocess/create',
     summary='Creates a new subprocess',
     response_model=models.VCSSubprocess,
 )
@@ -240,7 +240,7 @@ async def create_subprocess(subprocess_post: models.VCSSubprocessPost, project_i
 
 
 @router.put(
-    '/project/{project_id}/subprocess/{subprocess_id}/edit/',
+    '/project/{project_id}/subprocess/{subprocess_id}/edit',
     summary='Edits a subprocess',
     response_model=models.VCSSubprocess,
 )
@@ -250,7 +250,7 @@ async def edit_subprocess(subprocess_id: int, project_id: int, vcs_post: models.
 
 
 @router.delete(
-    '/project/{project_id}/subprocess/{subprocess_id}/delete/',
+    '/project/{project_id}/subprocess/{subprocess_id}/delete',
     summary='Deletes a subprocess',
     response_model=bool,
 )
@@ -260,7 +260,7 @@ async def delete_subprocess(subprocess_id: int, project_id: int,
 
 
 @router.put(
-    '/project/{project_id}/subprocess/update-indices/',
+    '/project/{project_id}/subprocess/update-indices',
     summary='Updates the indices of multiple subprocesses',
     response_model=bool,
 )

--- a/apps/difam/router.py
+++ b/apps/difam/router.py
@@ -15,7 +15,7 @@ router = APIRouter()
 DIFAM_APP_SID = 'MOD.DIFAM'
 
 
-@router.get("/projects/",
+@router.get("/projects",
             summary="List available DIFAM projects",
             response_model=ListChunk[models.DifamProject])
 async def get_difam_projects(segment_length: int, index: int, current_user: User = Depends(get_current_active_user)) \
@@ -36,7 +36,7 @@ async def get_difam_project(native_project_id: int) -> models.DifamProject:
     return impl.impl_get_difam_project(native_project_id)
 
 
-@router.post("/projects/",
+@router.post("/projects",
              summary="Create new DIFAM project",
              response_model=models.DifamProject)
 async def post_difam_project(difam_project_post: models.DifamProjectPost,

--- a/tests/apps/core/projects/test_projects.py
+++ b/tests/apps/core/projects/test_projects.py
@@ -13,7 +13,7 @@ import apps.core.projects.models as models
 
 def test_get_projects_unauthenticated(client):
     # Act
-    res = client.get('/api/core/projects/?segment_length=10&index=0')
+    res = client.get('/api/core/projects?segment_length=10&index=0')
     # assert
     assert res.status_code == 401
 
@@ -24,7 +24,7 @@ def test_get_projects(client, std_headers, std_user):
     current_user = impl_users.impl_get_user_with_username(std_user.username)
     seeded_projects = tu_projects.seed_random_projects(current_user.id, amount=r.randint(5, max_projects))
     # Act
-    res = client.get(f'/api/core/projects/?segment_length={max_projects}&index=0', headers=std_headers)
+    res = client.get(f'/api/core/projects?segment_length={max_projects}&index=0', headers=std_headers)
     # Assert
     assert res.status_code == 200
     assert len(res.json()) == len(seeded_projects)
@@ -181,7 +181,7 @@ def test_add_participant_as_admin(client, std_headers, std_user):
     p = tu_projects.seed_random_project(owner_user.id)
     access_level = models.AccessLevel.EDITOR
     # Act
-    res = client.post(f'/api/core/projects/{p.id}/participants/'
+    res = client.post(f'/api/core/projects/{p.id}/participants'
                       f'?user_id={participant_user.id}'
                       f'&access_level={access_level.value}', headers=std_headers)
     p_updated = impl.impl_get_project(p.id)
@@ -211,7 +211,7 @@ def test_add_participant_as_non_admin(client, std_headers, std_user):
     })
     access_level = models.AccessLevel.EDITOR
     # Act
-    res = client.post(f'/api/core/projects/{p.id}/participants/'
+    res = client.post(f'/api/core/projects/{p.id}/participants'
                       f'?user_id={participant_user.id}'
                       f'&access_level={access_level.value}', headers=std_headers)
     p_updated = impl.impl_get_project(p.id)

--- a/tests/apps/core/projects/test_subprojects.py
+++ b/tests/apps/core/projects/test_subprojects.py
@@ -39,9 +39,9 @@ def test_get_subprojects(client, std_headers, std_user):
                    tu_projects.seed_random_subproject(third_user.id, p1.id),
                    tu_projects.seed_random_subproject(third_user.id, p2.id)]
     # Act
-    res1 = client.get(f'/api/core/projects/{p1.id}/subprojects/', headers=std_headers)
-    res2 = client.get(f'/api/core/projects/{p2.id}/subprojects/', headers=std_headers)
-    res3 = client.get(f'/api/core/projects/{p3.id}/subprojects/', headers=std_headers)
+    res1 = client.get(f'/api/core/projects/{p1.id}/subprojects', headers=std_headers)
+    res2 = client.get(f'/api/core/projects/{p2.id}/subprojects', headers=std_headers)
+    res3 = client.get(f'/api/core/projects/{p3.id}/subprojects', headers=std_headers)
     # Assert
     assert res1.status_code == 200
     assert len(res1.json()) == 3
@@ -61,7 +61,7 @@ def test_create_subproject(client, std_headers, std_user):
     random_native_project_id = random.randint(0, 99999)
     app_sid = "MOD.EFM"
     # Act
-    res = client.post(f'/api/core/projects/{p.id}/subprojects/',
+    res = client.post(f'/api/core/projects/{p.id}/subprojects',
                       headers=std_headers,
                       json={
                           "application_sid": app_sid,

--- a/tests/apps/core/users/test_users.py
+++ b/tests/apps/core/users/test_users.py
@@ -5,7 +5,7 @@ import tests.apps.core.users.testutils as tu_users
 
 def test_create_user(client, admin_headers):
     # Act
-    res = client.post("/api/core/users/",
+    res = client.post("/api/core/users",
                       headers=admin_headers,
                       json={
                           "username": tu.random_str(3, 40),
@@ -85,7 +85,7 @@ def test_get_users_unauthenticated(client):
 
 def test_post_user_unauthenticated(client):
     # Act
-    res = client.post("/api/core/users/",
+    res = client.post("/api/core/users",
                       json={
                           "username": tu.random_str(3, 40),
                           "email": tu.random_str(3, 40) + "@gmail.com",


### PR DESCRIPTION
Changing all endpoints such that none of them has a trailing forward slash.

This is primarily to make it easier for front-end developers, but also for back-end developers who may not be certain whether or not an endpoint should have a trailing slash or not.

Closes #59 